### PR TITLE
Don't change anything if not configured

### DIFF
--- a/app/code/community/Phpro/RemoteMedia/Helper/Data.php
+++ b/app/code/community/Phpro/RemoteMedia/Helper/Data.php
@@ -39,7 +39,7 @@ class Phpro_RemoteMedia_Helper_Data extends Mage_Core_Helper_Abstract
     public function fetchRemoteProductionImage($filename)
     {
         if(!$this->getRemoteMediaEnabled() || $this->getProductionMediaUrl() == '' || $filename == '') {
-            return false;
+            return $filename;
         }
 
         $relativeFilePath = '/catalog/product' . $filename;


### PR DESCRIPTION
When installed on a production site and not enabled, `parent::setBaseFile()` is called with `false` instead of the original parameter. This breaks the images.
